### PR TITLE
fix(video_dl): correct boost tier 1 upload size mapping

### DIFF
--- a/video_dl/video_dl.py
+++ b/video_dl/video_dl.py
@@ -19,7 +19,7 @@ class VideoDownloader(commands.Cog):
     # Discord file size limits by boost level (in bytes)
     FILE_SIZE_LIMITS = {
         0: 25 * 1024 * 1024,   # 25MB for non-boosted
-        1: 10 * 1024 * 1024,   # 10MB for level 1
+        1: 25 * 1024 * 1024,   # 25MB for level 1
         2: 50 * 1024 * 1024,   # 50MB for level 2
         3: 100 * 1024 * 1024,  # 100MB for level 3
     }


### PR DESCRIPTION
The video upload limit mapping for ideo_dl had an invalid tier progression: boost tier 1 was set to 10MB while tier 0 was 25MB. This made boosted servers more restrictive than non-boosted servers.

This change updates FILE_SIZE_LIMITS so tier 1 matches Discord's expected limit behavior.

- Tier 0: 25MB
- Tier 1: 25MB
- Tier 2: 50MB
- Tier 3: 100MB

Fixes: #148