### PR TITLE
fix: remove invoke_without_command anti-pattern from hybrid groups

### DIFF
--- a/access/access.py
+++ b/access/access.py
@@ -15,10 +15,9 @@ class Access(commands.Cog):
 
     @commands.guild_only()
     @checks.mod_or_permissions(manage_roles=True)
-    @commands.hybrid_group(name="access", invoke_without_command=True)
+    @commands.hybrid_group(name="access")
     async def access(self, ctx):
         """Manage channel access permissions for roles and members"""
-        await ctx.send_help(ctx.command)
 
     @access.command(name="give")
     async def access_give(

--- a/activity_stats/activity_stats.py
+++ b/activity_stats/activity_stats.py
@@ -104,10 +104,9 @@ class ActivityStats(commands.Cog):
                         del last_activity_update[user_id_str]
 
     @commands.guild_only()
-    @commands.hybrid_group(name="activity", invoke_without_command=True)
+    @commands.hybrid_group(name="activity")
     async def activity_group(self, ctx):
         """Activity tracking commands"""
-        await ctx.send_help()
 
     @activity_group.command(name="topgames")
     async def top_games(self, ctx, limit: int = 10):
@@ -290,11 +289,10 @@ class ActivityStats(commands.Cog):
 
         await ctx.send(embed=embed, ephemeral=True)
 
-    @activity_group.group(name="set", invoke_without_command=True)
+    @activity_group.group(name="set")
     @commands.has_permissions(manage_guild=True)
     async def set_config(self, ctx):
         """Configure activity tracking settings"""
-        await ctx.send_help()
 
     @set_config.command(name="enabled")
     @commands.has_permissions(manage_guild=True)

--- a/albion_bandits/bandits.py
+++ b/albion_bandits/bandits.py
@@ -600,11 +600,10 @@ class AlbionBandits(commands.Cog):
 
         log.info(f"Recorded NATS bandit call for guild {guild.name}")
 
-    @commands.hybrid_group(invoke_without_command=True)
+    @commands.hybrid_group()
     @commands.guild_only()
     async def bandits(self, ctx):
         """Manage bandit tracking"""
-        await ctx.send_help()
 
     @bandits.command(name="next")
     async def bandits_next(self, ctx):

--- a/game_embed/game_embed.py
+++ b/game_embed/game_embed.py
@@ -226,11 +226,9 @@ class GameEmbed(commands.Cog):
             logger.exception(f"Error updating embed: {e}")
 
     @commands.guild_only()
-    @commands.hybrid_group(name="gameserver", invoke_without_command=True)
+    @commands.hybrid_group(name="gameserver")
     async def gameserver_group(self, ctx):
-        await ctx.defer()
         """Game server monitoring commands."""
-        await ctx.send_help()
 
     @gameserver_group.command(name="add")
     @commands.admin_or_permissions(manage_guild=True)

--- a/hat/hat.py
+++ b/hat/hat.py
@@ -307,14 +307,13 @@ class Hat(commands.Cog):
         msg = await ctx.send(embed=embed, file=file)
         await self._track_preview_message(ctx, msg)
 
-    @commands.hybrid_group(name="hat", invoke_without_command=True)
+    @commands.hybrid_group(name="hat")
     async def _hat(self, ctx):
         """Add a festive Christmas hat to your avatar!
 
         Commands automatically show a live preview and save your settings.
         Use `/hat show` to refresh the preview with your current avatar.
         """
-        await ctx.send_help(ctx.command)
 
     @_hat.command(name="list")
     async def _hat_list(self, ctx):
@@ -514,11 +513,10 @@ class Hat(commands.Cog):
         await self._send_live_preview(ctx)
 
     # Admin commands
-    @commands.hybrid_group(name="sethat", invoke_without_command=True)
+    @commands.hybrid_group(name="sethat")
     @checks.admin_or_permissions(manage_guild=True)
     async def _sethat(self, ctx):
         """Admin commands for managing hats"""
-        await ctx.send_help(ctx.command)
 
     @_sethat.command(name="upload")
     @checks.admin_or_permissions(manage_guild=True)

--- a/movie_vote/movie_vote.py
+++ b/movie_vote/movie_vote.py
@@ -48,17 +48,17 @@ class MovieVote(commands.Cog):
         log.debug("Checking %s episodes against '%s'", len(all_data), imdb_id)
         return next((x for x in all_data if x.get('imdb_id', '') == f"tt{imdb_id}"), None)
 
-    @commands.hybrid_group(autohelp=False)
+    @commands.hybrid_group()
     @commands.guild_only()
     @checks.admin_or_permissions(manage_guild=True)
     async def movie(self, ctx):
         """Movie cog settings"""
 
-        if ctx.invoked_subcommand is not None:
-            return
-
-        await ctx.send_help()
-
+    @movie.command(name="status")
+    @commands.guild_only()
+    @checks.admin_or_permissions(manage_guild=True)
+    async def _movievote_status(self, ctx):
+        """Show active channels and emoji configuration"""
         guild_data = await self.config.guild(ctx.guild).all()
         bad_channels = []
         msg = "Active Channels:\n"

--- a/psymin/psymin.py
+++ b/psymin/psymin.py
@@ -14,11 +14,10 @@ class Psymin(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.hybrid_group(name="psymin", invoke_without_command=True)
+    @commands.hybrid_group(name="psymin")
     @commands.is_owner()
     async def psymin(self, ctx):
         """Bot owner administration commands"""
-        await ctx.send_help(ctx.command)
 
     @psymin.command(name="permissions")
     async def permissions(self, ctx):

--- a/user/user.py
+++ b/user/user.py
@@ -162,10 +162,9 @@ class User(commands.Cog):
         await self.bot.http.request(route, json=payload)
 
     @commands.guild_only()
-    @commands.hybrid_group(name="user", invoke_without_command=True)
+    @commands.hybrid_group(name="user")
     async def _user(self, ctx):
         """Manage bot user settings"""
-        await ctx.send_help(ctx.command)
 
     @commands.guild_only()
     @_user.command(name="nick")


### PR DESCRIPTION
## Why

Several hybrid command groups across the codebase used `invoke_without_command=True` (or Red-bot's `autohelp=False`) solely to manually call `ctx.send_help()` when no subcommand was given. The Red-bot/Discord.py framework already handles this automatically, so the extra code was dead weight that added maintenance risk and diverged from framework conventions.

## What changed

For each affected group, `invoke_without_command=True` (or `autohelp=False`) was removed from the decorator and the body was reduced to just the docstring. The framework now handles the no-subcommand case natively.

Cogs fixed:
- `access` -- `access` group
- `activity_stats` -- `activity_group` and `set_config` subgroup
- `albion_bandits` -- `bandits` group
- `game_embed` -- `gameserver_group` (also fixes a misplaced docstring that appeared after `await ctx.defer()`)
- `hat` -- `_hat` and `_sethat` groups
- `psymin` -- `psymin` group
- `user` -- `_user` group

## Special case: movie_vote

The `movie` group used `autohelp=False` and `invoked_subcommand is not None` checks, but also ran real logic (displaying active channels and emoji config) when called without a subcommand. The anti-pattern was removed and the config display was extracted into a new `movie status` subcommand so the functionality is preserved under an explicit, discoverable command.

## Not changed: assign_roles

`assign_roles` uses `invoke_without_command=True` legitimately -- its group body performs actual role assignment rather than just showing help. This is a valid use of the pattern and was left untouched.

Fixes: #150
