### PR TITLE
fix: replace private httpx._exceptions usage in movie_vote and tgmc

### DIFF
--- a/movie_vote/movie_vote.py
+++ b/movie_vote/movie_vote.py
@@ -592,6 +592,6 @@ async def http_get(url):
             else:
                 attempt += 1
             await asyncio.sleep(1)
-        except (httpx._exceptions.ConnectTimeout, httpx._exceptions.HTTPError):
+        except (httpx.ConnectTimeout, httpx.HTTPError):
             attempt += 1
             await asyncio.sleep(1)

--- a/tgmc/api.py
+++ b/tgmc/api.py
@@ -27,7 +27,7 @@ async def http_get(url):
             else:
                 attempt += 1
             await asyncio.sleep(5)
-        except (httpx._exceptions.ConnectTimeout, httpx._exceptions.HTTPError):
+        except (httpx.ConnectTimeout, httpx.HTTPError):
             attempt += 1
             await asyncio.sleep(5)
             pass


### PR DESCRIPTION
Fixes #149

## Changes

Replaced \httpx._exceptions.ConnectTimeout\ and \httpx._exceptions.HTTPError\ with their public equivalents \httpx.ConnectTimeout\ and \httpx.HTTPError\ in:

- \movie_vote/movie_vote.py\
- \	gmc/api.py\

This matches the pattern already used by other cogs (\ideas\, \lbion_auth\, \lbion_ava\, \lbion_regear\).