### PR TITLE
feat(party): add total signups count to embed title

### DIFF
--- a/party/party.py
+++ b/party/party.py
@@ -1288,8 +1288,12 @@ class Party(commands.Cog):
             party: The party data dictionary
             guild: Optional guild object to resolve the owner's display name
         """
+        # Show roles and signups
+        signups = party.get("signups", {})
+        total_signups = sum(len(users) for users in signups.values())
+
         embed = discord.Embed(
-            title=f"🎉 {party['name']}",
+            title=f"🎉 {party['name']} ({total_signups} signed up)",
             description=party.get("description", "Join the party by selecting your role!"),
             color=discord.Color.blue()
         )
@@ -1310,8 +1314,6 @@ class Party(commands.Cog):
             except (ValueError, OSError):
                 pass
 
-        # Show roles and signups
-        signups = party.get("signups", {})
         roles = party.get("roles", [])
 
         # Add each role as a field


### PR DESCRIPTION
Party embeds previously showed only the party name in the title, giving no at-a-glance indication of how many people had signed up. Users had to count entries across multiple role fields themselves.

The `create_party_embed` method now calculates the total number of signups across all roles (predefined and freeform) and appends the count to the embed title:

```
🎉 Party Name (5 signed up)
```

The count is recomputed each time the embed is generated, so it always stays accurate as people join or leave.

Fixes: #157