### PR TITLE
refactor(party): extract has_party_permission helper to remove 7x copy-paste

### DIFF
--- a/party/helpers.py
+++ b/party/helpers.py
@@ -5,6 +5,11 @@ IDENTIFIER = 2847102938475019
 EMBED_FIELD_MAX_LENGTH = 1024
 
 
+def has_party_permission(party: dict, user) -> bool:
+    """Return True if user is the party author or a server administrator."""
+    return party["author_id"] == user.id or user.guild_permissions.administrator
+
+
 def parse_allow_multiple(allow_multiple_text: str) -> tuple[bool, Optional[str]]:
     """Parse and validate allow_multiple_per_role setting."""
     allow_multiple_text = allow_multiple_text.strip().lower()

--- a/party/party.py
+++ b/party/party.py
@@ -11,6 +11,7 @@ from .helpers import (
     EMBED_FIELD_MAX_LENGTH,
     _parse_roles_from_args,
     format_timestamp,
+    has_party_permission,
     parse_scheduled_time,
     validate_roles,
 )
@@ -615,10 +616,7 @@ class Party(commands.Cog):
                 party_id, party = matching_parties[0]
 
         # Check permissions
-        is_author = party["author_id"] == ctx.author.id
-        is_admin = ctx.author.guild_permissions.administrator
-
-        if not (is_author or is_admin):
+        if not has_party_permission(party, ctx.author):
             await ctx.send("❌ You don't have permission to delete this party.")
             return
 
@@ -787,10 +785,7 @@ class Party(commands.Cog):
         party = parties[party_id]
 
         # Check permissions
-        is_author = party["author_id"] == ctx.author.id
-        is_admin = ctx.author.guild_permissions.administrator
-
-        if not (is_author or is_admin):
+        if not has_party_permission(party, ctx.author):
             await ctx.send("❌ You don't have permission to modify this party.")
             return
 
@@ -843,10 +838,7 @@ class Party(commands.Cog):
         party = parties[party_id]
 
         # Check permissions
-        is_author = party["author_id"] == ctx.author.id
-        is_admin = ctx.author.guild_permissions.administrator
-
-        if not (is_author or is_admin):
+        if not has_party_permission(party, ctx.author):
             await ctx.send("❌ You don't have permission to modify this party.")
             return
 
@@ -914,10 +906,7 @@ class Party(commands.Cog):
         party = parties[party_id]
 
         # Check permissions
-        is_author = party["author_id"] == ctx.author.id
-        is_admin = ctx.author.guild_permissions.administrator
-
-        if not (is_author or is_admin):
+        if not has_party_permission(party, ctx.author):
             await ctx.send("❌ You don't have permission to modify this party.")
             return
 
@@ -963,10 +952,7 @@ class Party(commands.Cog):
         party = parties[party_id]
 
         # Check permissions
-        is_author = party["author_id"] == ctx.author.id
-        is_admin = ctx.author.guild_permissions.administrator
-
-        if not (is_author or is_admin):
+        if not has_party_permission(party, ctx.author):
             await ctx.send("❌ You don't have permission to modify this party.")
             return
 

--- a/party/views.py
+++ b/party/views.py
@@ -7,6 +7,7 @@ import discord
 
 from .helpers import (
     format_timestamp,
+    has_party_permission,
     parse_roles_from_text,
     parse_scheduled_time,
     parse_settings_text,
@@ -678,10 +679,7 @@ class PartyView(discord.ui.View):
             return
 
         # Check permissions
-        is_author = party["author_id"] == interaction.user.id
-        is_admin = interaction.user.guild_permissions.administrator
-
-        if not (is_author or is_admin):
+        if not has_party_permission(party, interaction.user):
             await interaction.response.send_message(
                 "❌ You don't have permission to edit this party.",
                 ephemeral=True
@@ -705,10 +703,7 @@ class PartyView(discord.ui.View):
             return
 
         # Check permissions
-        is_author = party["author_id"] == interaction.user.id
-        is_admin = interaction.user.guild_permissions.administrator
-
-        if not (is_author or is_admin):
+        if not has_party_permission(party, interaction.user):
             await interaction.followup.send(
                 "❌ You don't have permission to delete this party.",
                 ephemeral=True


### PR DESCRIPTION
Closes #168

## What

The `is_author / is_admin / if not (is_author or is_admin)` block was copy-pasted 7 times. Extracted `has_party_permission(party, user)` to `helpers.py` (avoids circular import since both `party.py` and `views.py` need it).

Call sites updated: `party_delete`, `party_description`, `party_settime`, `party_compact`, `party_rename_option`, `PartyView.edit_button`, `PartyView.delete_button`.

## Validation
- `python -m py_compile party/helpers.py party/party.py party/views.py` — clean
- `flake8 party/ --select=F821,E9,W` — clean
