### PR TITLE
Add cookie auth support for restricted TikTok/Instagram content

### DIFF
--- a/video_dl/video_dl.py
+++ b/video_dl/video_dl.py
@@ -293,6 +293,24 @@ class VideoDownloader(commands.Cog):
             log.exception(f"Unexpected error downloading video: {e}")
             return False, None, f"Unexpected error: {str(e)}"
 
+    def _is_auth_error(self, error_msg: str) -> bool:
+        """Return True if the error looks like a cookie/auth failure."""
+        if not error_msg:
+            return False
+        lower = error_msg.lower()
+        return any(kw in lower for kw in (
+            "permission", "log in", "login", "cookie",
+            "authentication", "not available", "private",
+        ))
+
+    async def _react_auth_error(self, message: discord.Message):
+        """React with ❌ 🍪 to signal a cookie auth failure."""
+        for emoji in ("❌", "🍪"):
+            try:
+                await message.add_reaction(emoji)
+            except discord.HTTPException:
+                pass
+
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
         """Listen for messages with video URLs.
@@ -390,7 +408,9 @@ class VideoDownloader(commands.Cog):
                                 await message.add_reaction(emoji)
                             except discord.HTTPException:
                                 pass
-                # Suppress error messages for automatic downloads
+                # React on auth failure; suppress all other download errors
+                elif self._is_auth_error(error_msg):
+                    await self._react_auth_error(message)
 
             finally:
                 # Clean up temporary directory
@@ -483,8 +503,15 @@ class VideoDownloader(commands.Cog):
                             ephemeral=True
                         )
                 else:
-                    # Send error message
-                    await ctx.send(f"❌ {error_msg}", ephemeral=True)
+                    # Send error message; hint about cookies on auth failures
+                    if self._is_auth_error(error_msg):
+                        await ctx.send(
+                            f"❌ 🍪 {error_msg}\n\n"
+                            "Use `[p]videodl setcookies <path>` to configure a cookies file.",
+                            ephemeral=True
+                        )
+                    else:
+                        await ctx.send(f"❌ {error_msg}", ephemeral=True)
 
             finally:
                 # Clean up temporary directory

--- a/video_dl/video_dl.py
+++ b/video_dl/video_dl.py
@@ -200,7 +200,10 @@ class VideoDownloader(commands.Cog):
                 return platform
         return None
 
-    async def _download_video(self, url: str, platform: str, temp_dir: str, guild: discord.Guild = None, cookies_file: str = None):
+    async def _download_video(
+        self, url: str, platform: str, temp_dir: str,
+        guild: discord.Guild = None, cookies_file: str = None
+    ):
         """Download video using yt-dlp.
 
         Parameters

--- a/video_dl/video_dl.py
+++ b/video_dl/video_dl.py
@@ -671,6 +671,7 @@ class VideoDownloader(commands.Cog):
         await self.config.guild(ctx.guild).too_large_emoji.set(emoji)
         await ctx.send(f"✅ Too large emoji has been set to {emoji}", ephemeral=True)
 
+    @commands.guild_only()
     @checks.is_owner()
     @videodl.command(name="setcookies")
     async def videodl_set_cookies(self, ctx, path: str = ""):

--- a/video_dl/video_dl.py
+++ b/video_dl/video_dl.py
@@ -58,6 +58,7 @@ class VideoDownloader(commands.Cog):
             "disabled_users": [],
             "catbox_userhash": "psykzz",
             "too_large_emoji": "💥",
+            "cookies_file": "",
         }
         self.config.register_guild(**default_guild)
 
@@ -199,7 +200,7 @@ class VideoDownloader(commands.Cog):
                 return platform
         return None
 
-    async def _download_video(self, url: str, platform: str, temp_dir: str, guild: discord.Guild = None):
+    async def _download_video(self, url: str, platform: str, temp_dir: str, guild: discord.Guild = None, cookies_file: str = None):
         """Download video using yt-dlp.
 
         Parameters
@@ -230,6 +231,9 @@ class VideoDownloader(commands.Cog):
             'no_warnings': True,
             'extract_flat': False,
         }
+
+        if cookies_file:
+            ydl_opts['cookiefile'] = cookies_file
 
         if platform == 'youtube':
             # YouTube: best video up to 1080p + best audio
@@ -321,9 +325,17 @@ class VideoDownloader(commands.Cog):
             # Create temporary directory
             temp_dir = tempfile.mkdtemp(prefix='video_dl_')
 
+            # Fetch cookies_file config for guild downloads
+            cookies_file = ""
+            if message.guild:
+                guild_config = await self.config.guild(message.guild).all()
+                cookies_file = guild_config.get("cookies_file", "")
+
             try:
                 # Download the video
-                success, file_path, error_msg = await self._download_video(url, platform, temp_dir, message.guild)
+                success, file_path, error_msg = await self._download_video(
+                    url, platform, temp_dir, message.guild, cookies_file or None
+                )
 
                 if success and file_path:
                     file_size = os.path.getsize(file_path)
@@ -407,9 +419,17 @@ class VideoDownloader(commands.Cog):
             # Create temporary directory
             temp_dir = tempfile.mkdtemp(prefix='video_dl_')
 
+            # Fetch cookies_file config
+            cookies_file = ""
+            if ctx.guild:
+                guild_cfg = await self.config.guild(ctx.guild).all()
+                cookies_file = guild_cfg.get("cookies_file", "")
+
             try:
                 # Download the video
-                success, file_path, error_msg = await self._download_video(url, platform, temp_dir, ctx.guild)
+                success, file_path, error_msg = await self._download_video(
+                    url, platform, temp_dir, ctx.guild, cookies_file or None
+                )
 
                 if success and file_path:
                     file_size = os.path.getsize(file_path)
@@ -587,6 +607,7 @@ class VideoDownloader(commands.Cog):
         disabled_users = guild_config["disabled_users"]
         catbox_userhash = guild_config.get("catbox_userhash", "")
         too_large_emoji = guild_config.get("too_large_emoji", "💥")
+        cookies_file = guild_config.get("cookies_file", "")
 
         # Get boost level and file size limit
         boost_level = ctx.guild.premium_tier
@@ -596,6 +617,7 @@ class VideoDownloader(commands.Cog):
         status_msg += f"Server-wide: {'✅ Enabled' if enabled else '❌ Disabled'}\n"
         status_msg += f"Boost Level: {boost_level} (File size limit: {file_size_limit / 1024 / 1024:.0f}MB)\n"
         status_msg += f"Catbox.moe: {'✅ Configured' if catbox_userhash else '❌ Not configured'}\n"
+        status_msg += f"Cookies file: {'✅ Configured' if cookies_file else '❌ Not configured'}\n"
         status_msg += f"Too large emoji: {too_large_emoji}\n\n"
 
         if disabled_channels:
@@ -648,3 +670,31 @@ class VideoDownloader(commands.Cog):
         await ctx.defer(ephemeral=True)
         await self.config.guild(ctx.guild).too_large_emoji.set(emoji)
         await ctx.send(f"✅ Too large emoji has been set to {emoji}", ephemeral=True)
+
+    @checks.is_owner()
+    @videodl.command(name="setcookies")
+    async def videodl_set_cookies(self, ctx, path: str = ""):
+        """Set the path to a Netscape cookies file for yt-dlp authentication.
+
+        Required for age-gated or login-only TikTok/Instagram content.
+        Export cookies from a logged-in browser using a cookies.txt extension.
+
+        Parameters
+        ----------
+        path : str, optional
+            Absolute path to the cookies file. Leave empty to clear.
+        """
+        await ctx.defer(ephemeral=True)
+
+        if path:
+            if not os.path.isfile(path):
+                await ctx.send(
+                    f"❌ File not found or not readable: `{path}`", ephemeral=True
+                )
+                return
+            await self.config.guild(ctx.guild).cookies_file.set(path)
+            await ctx.send("✅ Cookies file has been set.", ephemeral=True)
+            log.info(f"Cookies file set to {path} for guild {ctx.guild.id}")
+        else:
+            await self.config.guild(ctx.guild).cookies_file.set("")
+            await ctx.send("✅ Cookies file has been cleared.", ephemeral=True)


### PR DESCRIPTION
## Summary

Some TikTok and Instagram posts require a logged-in session to view. yt-dlp surfaces this as a hard download error:

```
ERROR: [TikTok] ...: You do not have permission to view this post.
Use --cookies-from-browser or --cookies for the authentication.
```

yt-dlp supports passing a Netscape-format cookies file (`cookiefile` option). This PR wires that up as a per-guild config key that bot owners can set via a new command.

## Changes

- Add `cookies_file` key to guild config (default `""`)
- Pass `cookiefile` into yt-dlp opts (both size-probe and download passes) when configured
- Add `[p]videodl setcookies <path>` command (bot owner only) — validates file exists on disk before saving
- `[p]videodl status` now shows whether a cookies file is configured

## Usage

Export cookies from a browser logged into TikTok/Instagram using a "cookies.txt" extension, then:

```
[p]videodl setcookies /path/to/cookies.txt
```

## Testing

- Python syntax: `python -m py_compile video_dl/video_dl.py` ✅
- Lint: `flake8 video_dl/video_dl.py --select=E9,F63,F7,F82` ✅
- End-to-end requires a live bot with a valid cookies file for a restricted post

## Risk

Low. `cookiefile` is only passed when non-empty; all existing behaviour unchanged when not configured. File-existence check prevents silent misconfiguration.

Closes #182
