### PR TITLE
feat(wordgame): inactivity timeout, per-player bonus guesses, DM opt-out

### DIFF
--- a/wordgame/views.py
+++ b/wordgame/views.py
@@ -38,3 +38,46 @@ class ScoreboardView(discord.ui.View):
             await interaction.followup.send(
                 "❌ No active game found in this thread.", ephemeral=True
             )
+
+
+class BonusDMView(discord.ui.View):
+    """View sent in bonus-guess DMs. Lets the player opt out of further DMs."""
+
+    def __init__(self, cog, thread_id: int, user_id: int):
+        super().__init__(timeout=None)
+        self.cog = cog
+        self.thread_id = thread_id
+        self.user_id = user_id
+
+        ignore_button = discord.ui.Button(
+            label="Stop DMs",
+            emoji="🚫",
+            style=discord.ButtonStyle.secondary,
+            custom_id=f"wordgame:ignore:{thread_id}:{user_id}",
+        )
+        ignore_button.callback = self._ignore_callback
+        self.add_item(ignore_button)
+
+    async def _ignore_callback(self, interaction: discord.Interaction):
+        await interaction.response.defer()
+
+        thread = self.cog.bot.get_channel(self.thread_id)
+        if thread:
+            async with self.cog.config.guild(thread.guild).active_games() as games:
+                game = games.get(str(self.thread_id))
+                if game:
+                    player = game.get("players", {}).get(str(self.user_id))
+                    if player:
+                        player["ignore_dms"] = True
+
+        # Disable the button and update the DM message
+        for item in self.children:
+            item.disabled = True
+        try:
+            await interaction.message.edit(
+                content=interaction.message.content
+                + "\n\n*✅ You won't receive further DMs for this game.*",
+                view=self,
+            )
+        except discord.HTTPException:
+            pass

--- a/wordgame/wordgame.py
+++ b/wordgame/wordgame.py
@@ -16,7 +16,7 @@ from .game import (
     get_random_word,
     is_valid_guess,
 )
-from .views import ScoreboardView
+from .views import BonusDMView, ScoreboardView
 
 log = logging.getLogger("red.cog.wordgame")
 
@@ -44,9 +44,6 @@ def _build_scoreboard_text(game: dict, reveal_word: bool = False) -> str:
     inactive_closes_at = game.get("inactive_closes_at")
     if inactive_closes_at and status == "active":
         header += f"\n⏳ Auto-closes <t:{int(inactive_closes_at)}:R> if no guesses"
-    next_bonus_at = game.get("next_bonus_at")
-    if next_bonus_at and status == "active":
-        header += f"\n⏰ Next bonus guess <t:{int(next_bonus_at)}:R>"
     if reveal_word:
         header += f"\n🔑 The word was: **{word.upper()}**"
     header += "\n"
@@ -58,7 +55,11 @@ def _build_scoreboard_text(game: dict, reveal_word: bool = False) -> str:
         )
         leaderboard = "\n📊 **Leaderboard**\n"
         for rank, (uid, pdata) in enumerate(sorted_players, 1):
-            done_marker = " ✅" if pdata.get("done") else ""
+            if pdata.get("done"):
+                bonus_at = pdata.get("bonus_guess_at")
+                done_marker = f" ⏰ <t:{int(bonus_at)}:R>" if bonus_at else " ✅"
+            else:
+                done_marker = ""
             leaderboard += f"{rank}. <@{uid}> — **{pdata['score']} pts**{done_marker}\n"
     else:
         leaderboard = "\n📊 **Leaderboard**\n*No guesses yet — type a word in this thread!*\n"
@@ -118,7 +119,7 @@ class WordGame(commands.Cog):
 
     @tasks.loop(seconds=30)
     async def _close_games_loop(self):
-        """End inactive games and grant bonus guesses on schedule."""
+        """End inactive games and grant per-player bonus guesses on schedule."""
         now = time.time()
         has_active = False
         all_guilds = await self.config.all_guilds()
@@ -135,9 +136,10 @@ class WordGame(commands.Cog):
                     has_active = False
                     continue
 
-                next_bonus_at = game.get("next_bonus_at")
-                if next_bonus_at and now >= next_bonus_at:
-                    await self._grant_bonus_guesses(thread_id, game)
+                for uid, player in game.get("players", {}).items():
+                    bonus_at = player.get("bonus_guess_at")
+                    if bonus_at and now >= bonus_at:
+                        await self._grant_bonus_guess(thread_id, game, uid, player)
 
         if not has_active:
             self._close_games_loop.stop()
@@ -146,35 +148,40 @@ class WordGame(commands.Cog):
     async def _before_close_games_loop(self):
         await self.bot.wait_until_ready()
 
-    async def _grant_bonus_guesses(self, thread_id: int, game: dict):
-        """Grant +1 guess to every done player and post a thread notification."""
+    async def _grant_bonus_guess(
+        self, thread_id: int, game: dict, user_id: str, player: dict
+    ):
+        """Grant +1 guess to a single player and DM them unless opted out."""
         thread = self.bot.get_channel(thread_id)
         if not thread:
             return
 
-        granted_to = []
-        for uid, player in game.get("players", {}).items():
-            if player.get("done"):
-                player["max_guesses"] = player.get("max_guesses", MAX_GUESSES) + 1
-                player["done"] = False
-                granted_to.append(uid)
-
-        # Advance the next bonus time regardless of whether anyone was granted
-        game["next_bonus_at"] = game["next_bonus_at"] + BONUS_GUESS_INTERVAL
+        player["max_guesses"] = player.get("max_guesses", MAX_GUESSES) + 1
+        player["done"] = False
+        player["bonus_guess_at"] = None
 
         async with self.config.guild(thread.guild).active_games() as games:
             games[str(thread_id)] = game
 
-        if granted_to:
-            mentions = " ".join(f"<@{uid}>" for uid in granted_to)
-            try:
-                await thread.send(
-                    f"⏰ **Bonus guess!** {mentions} — you each have 1 more guess."
-                )
-            except discord.HTTPException:
-                pass
-
         await self._update_scoreboard(thread, game)
+
+        if player.get("ignore_dms"):
+            return
+
+        user = self.bot.get_user(int(user_id))
+        if not user:
+            return
+        try:
+            view = BonusDMView(self, thread_id, int(user_id))
+            self.bot.add_view(view)
+            await user.send(
+                f"⏰ **Bonus guess!** You have an extra guess waiting in "
+                f"**Word Game** (Game `#{game['game_id']}`) — head back to "
+                f"{thread.mention} and use it!",
+                view=view,
+            )
+        except discord.HTTPException:
+            pass
 
     # ------------------------------------------------------------------ #
     #  Commands                                                            #
@@ -248,7 +255,6 @@ class WordGame(commands.Cog):
             "scoreboard_message_id": None,
             "claimed_positions": [],
             "inactive_closes_at": time.time() + INACTIVITY_TIMEOUT,
-            "next_bonus_at": time.time() + BONUS_GUESS_INTERVAL,
             "players": {},
         }
 
@@ -376,6 +382,8 @@ class WordGame(commands.Cog):
                 "score": 0,
                 "done": False,
                 "max_guesses": MAX_GUESSES,
+                "bonus_guess_at": None,
+                "ignore_dms": False,
             },
         )
 
@@ -416,6 +424,7 @@ class WordGame(commands.Cog):
         guesses_used = len(player["guesses"])
         if guesses_used >= player["max_guesses"] or guess == word:
             player["done"] = True
+            player["bonus_guess_at"] = time.time() + BONUS_GUESS_INTERVAL
 
         # Reset the inactivity timer on every valid guess
         game["inactive_closes_at"] = time.time() + INACTIVITY_TIMEOUT

--- a/wordgame/wordgame.py
+++ b/wordgame/wordgame.py
@@ -1,8 +1,10 @@
 import logging
 import secrets
 import string
+import time
 
 import discord
+from discord.ext import tasks
 from redbot.core import Config, checks, commands
 
 from .game import (
@@ -18,6 +20,7 @@ from .views import ScoreboardView
 
 log = logging.getLogger("red.cog.wordgame")
 
+INACTIVITY_TIMEOUT = 600  # 10 minutes without a guess → end game
 IDENTIFIER = 7391028475916283
 
 
@@ -37,6 +40,9 @@ def _build_scoreboard_text(game: dict, reveal_word: bool = False) -> str:
     status_icon = "🟢 Active" if status == "active" else "🔴 Ended"
     header = f"🎮 **Word Game** — {length} letters | Game `#{game_id}`\n"
     header += f"Status: {status_icon}"
+    inactive_closes_at = game.get("inactive_closes_at")
+    if inactive_closes_at and status == "active":
+        header += f"\n⏳ Auto-closes <t:{int(inactive_closes_at)}:R> if no guesses"
     if reveal_word:
         header += f"\n🔑 The word was: **{word.upper()}**"
     header += "\n"
@@ -85,10 +91,15 @@ class WordGame(commands.Cog):
         self.config.register_guild(**default_guild)
 
         self.bot.loop.create_task(self._register_persistent_views())
+        self._close_games_loop.start()
+
+    def cog_unload(self):
+        self._close_games_loop.cancel()
 
     async def _register_persistent_views(self):
         """Re-register ScoreboardView for all active games after a restart."""
         await self.bot.wait_until_ready()
+        has_active = False
         all_guilds = await self.config.all_guilds()
         for guild_data in all_guilds.values():
             for thread_id_str, game in guild_data.get("active_games", {}).items():
@@ -97,6 +108,31 @@ class WordGame(commands.Cog):
                     msg_id = game.get("scoreboard_message_id")
                     view = ScoreboardView(self, thread_id)
                     self.bot.add_view(view, message_id=msg_id)
+                    has_active = True
+        if has_active and not self._close_games_loop.is_running():
+            self._close_games_loop.start()
+
+    @tasks.loop(seconds=30)
+    async def _close_games_loop(self):
+        """End games that have been inactive for 10 minutes."""
+        now = time.time()
+        has_active = False
+        all_guilds = await self.config.all_guilds()
+        for guild_id, guild_data in all_guilds.items():
+            for thread_id_str, game in guild_data.get("active_games", {}).items():
+                if game.get("status") != "active":
+                    continue
+                has_active = True
+                closes_at = game.get("inactive_closes_at")
+                if closes_at and now >= closes_at:
+                    await self.end_game(int(thread_id_str))
+                    has_active = False
+        if not has_active:
+            self._close_games_loop.stop()
+
+    @_close_games_loop.before_loop
+    async def _before_close_games_loop(self):
+        await self.bot.wait_until_ready()
 
     # ------------------------------------------------------------------ #
     #  Commands                                                            #
@@ -169,6 +205,7 @@ class WordGame(commands.Cog):
             "announce_message_id": announce_msg.id,
             "scoreboard_message_id": None,
             "claimed_positions": [],
+            "inactive_closes_at": time.time() + INACTIVITY_TIMEOUT,
             "players": {},
         }
 
@@ -183,6 +220,10 @@ class WordGame(commands.Cog):
 
         # Register the persistent view now that we have the message id
         self.bot.add_view(view, message_id=scoreboard_msg.id)
+
+        # Ensure the inactivity watcher is running
+        if not self._close_games_loop.is_running():
+            self._close_games_loop.start()
 
         await ctx.send(
             f"✅ Game started! Head to {thread.mention} to play.", ephemeral=True
@@ -326,6 +367,9 @@ class WordGame(commands.Cog):
         if guesses_used >= MAX_GUESSES or guess == word:
             player["done"] = True
 
+        # Reset the inactivity timer on every valid guess
+        game["inactive_closes_at"] = time.time() + INACTIVITY_TIMEOUT
+
         # Persist
         async with self.config.guild(guild).active_games() as games:
             games[str(thread.id)] = game
@@ -343,12 +387,7 @@ class WordGame(commands.Cog):
         except discord.HTTPException:
             pass
 
-        # Check if all players are done — end_game will update scoreboard with reveal
-        all_done = game["players"] and all(p["done"] for p in game["players"].values())
-        if all_done:
-            await self.end_game(thread.id)
-        else:
-            await self._update_scoreboard(thread, game)
+        await self._update_scoreboard(thread, game)
 
     # ------------------------------------------------------------------ #
     #  Event listener                                                      #

--- a/wordgame/wordgame.py
+++ b/wordgame/wordgame.py
@@ -21,6 +21,7 @@ from .views import ScoreboardView
 log = logging.getLogger("red.cog.wordgame")
 
 INACTIVITY_TIMEOUT = 600  # 10 minutes without a guess → end game
+BONUS_GUESS_INTERVAL = 300  # 5 minutes → grant +1 guess to all done players
 IDENTIFIER = 7391028475916283
 
 
@@ -43,6 +44,9 @@ def _build_scoreboard_text(game: dict, reveal_word: bool = False) -> str:
     inactive_closes_at = game.get("inactive_closes_at")
     if inactive_closes_at and status == "active":
         header += f"\n⏳ Auto-closes <t:{int(inactive_closes_at)}:R> if no guesses"
+    next_bonus_at = game.get("next_bonus_at")
+    if next_bonus_at and status == "active":
+        header += f"\n⏰ Next bonus guess <t:{int(next_bonus_at)}:R>"
     if reveal_word:
         header += f"\n🔑 The word was: **{word.upper()}**"
     header += "\n"
@@ -114,7 +118,7 @@ class WordGame(commands.Cog):
 
     @tasks.loop(seconds=30)
     async def _close_games_loop(self):
-        """End games that have been inactive for 10 minutes."""
+        """End inactive games and grant bonus guesses on schedule."""
         now = time.time()
         has_active = False
         all_guilds = await self.config.all_guilds()
@@ -123,16 +127,54 @@ class WordGame(commands.Cog):
                 if game.get("status") != "active":
                     continue
                 has_active = True
+                thread_id = int(thread_id_str)
+
                 closes_at = game.get("inactive_closes_at")
                 if closes_at and now >= closes_at:
-                    await self.end_game(int(thread_id_str))
+                    await self.end_game(thread_id)
                     has_active = False
+                    continue
+
+                next_bonus_at = game.get("next_bonus_at")
+                if next_bonus_at and now >= next_bonus_at:
+                    await self._grant_bonus_guesses(thread_id, game)
+
         if not has_active:
             self._close_games_loop.stop()
 
     @_close_games_loop.before_loop
     async def _before_close_games_loop(self):
         await self.bot.wait_until_ready()
+
+    async def _grant_bonus_guesses(self, thread_id: int, game: dict):
+        """Grant +1 guess to every done player and post a thread notification."""
+        thread = self.bot.get_channel(thread_id)
+        if not thread:
+            return
+
+        granted_to = []
+        for uid, player in game.get("players", {}).items():
+            if player.get("done"):
+                player["max_guesses"] = player.get("max_guesses", MAX_GUESSES) + 1
+                player["done"] = False
+                granted_to.append(uid)
+
+        # Advance the next bonus time regardless of whether anyone was granted
+        game["next_bonus_at"] = game["next_bonus_at"] + BONUS_GUESS_INTERVAL
+
+        async with self.config.guild(thread.guild).active_games() as games:
+            games[str(thread_id)] = game
+
+        if granted_to:
+            mentions = " ".join(f"<@{uid}>" for uid in granted_to)
+            try:
+                await thread.send(
+                    f"⏰ **Bonus guess!** {mentions} — you each have 1 more guess."
+                )
+            except discord.HTTPException:
+                pass
+
+        await self._update_scoreboard(thread, game)
 
     # ------------------------------------------------------------------ #
     #  Commands                                                            #
@@ -206,6 +248,7 @@ class WordGame(commands.Cog):
             "scoreboard_message_id": None,
             "claimed_positions": [],
             "inactive_closes_at": time.time() + INACTIVITY_TIMEOUT,
+            "next_bonus_at": time.time() + BONUS_GUESS_INTERVAL,
             "players": {},
         }
 
@@ -326,7 +369,14 @@ class WordGame(commands.Cog):
         players = game.setdefault("players", {})
         player = players.setdefault(
             user_id,
-            {"guesses": [], "feedbacks": [], "points_per_guess": [], "score": 0, "done": False},
+            {
+                "guesses": [],
+                "feedbacks": [],
+                "points_per_guess": [],
+                "score": 0,
+                "done": False,
+                "max_guesses": MAX_GUESSES,
+            },
         )
 
         if player["done"]:
@@ -364,7 +414,7 @@ class WordGame(commands.Cog):
         game["claimed_positions"].extend(new_claims)
 
         guesses_used = len(player["guesses"])
-        if guesses_used >= MAX_GUESSES or guess == word:
+        if guesses_used >= player["max_guesses"] or guess == word:
             player["done"] = True
 
         # Reset the inactivity timer on every valid guess
@@ -375,7 +425,7 @@ class WordGame(commands.Cog):
             games[str(thread.id)] = game
 
         # Reply with feedback
-        guesses_left = MAX_GUESSES - guesses_used
+        guesses_left = player["max_guesses"] - guesses_used
         feedback_display = " ".join(f"`{c}`" for c in feedback)
         reply = (
             f"{feedback_display}\n"


### PR DESCRIPTION
## Summary

Follow-up to #184 — adds inactivity-based auto-close, per-player bonus guesses, and a DM re-engagement system with opt-out.

## Changes

- **Inactivity timeout** (`INACTIVITY_TIMEOUT = 600`): game auto-closes after 10 minutes of no guesses. Every valid guess resets the clock. Countdown shown in the scoreboard header.
- **Per-player bonus guesses** (`BONUS_GUESS_INTERVAL = 300`): 5 minutes after a player uses their last guess, they gain +1 more. Each player's timer is independent. Scoreboard shows personal countdown per done player.
- **DM opt-out** (`BonusDMView`): bonus notification is sent as a DM with a 🚫 Stop DMs button. Clicking it sets `ignore_dms = True` — no further DMs for that game.

## Testing

- `python -m py_compile wordgame/*.py` ✅
- `flake8 wordgame/ --max-line-length=100` ✅
