### PR TITLE
fix(wordgame): correct scoring, game-end on correct guess, and concurrent guess race

### DIFF
--- a/wordgame/game.py
+++ b/wordgame/game.py
@@ -89,15 +89,14 @@ def compute_score(
     seen_letters = set()  # deduplicate within this guess
 
     for i, (g, fb) in enumerate(zip(guess.lower(), feedback)):
-        if g in seen_letters:
-            continue
-
-        if fb in ("?", "!"):
-            points += 1  # letter appears in word
+        # Letter bonus: once per unique letter per guess
+        if fb in ("?", "!") and g not in seen_letters:
+            points += 1
             seen_letters.add(g)
 
+        # Position bonus: per (letter, position) globally — not skipped by seen_letters
         if fb == "!" and (g, i) not in claimed_set:
-            points += 1  # position bonus (globally unclaimed)
+            points += 1
             new_claims.append([g, i])
             claimed_set.add((g, i))
 

--- a/wordgame/wordgame.py
+++ b/wordgame/wordgame.py
@@ -107,8 +107,6 @@ class WordGame(commands.Cog):
 
     def _get_thread_lock(self, thread_id: int):
         """Return (creating if necessary) a per-thread asyncio.Lock."""
-        import asyncio
-
         if thread_id not in self._guess_locks:
             self._guess_locks[thread_id] = asyncio.Lock()
         return self._guess_locks[thread_id]

--- a/wordgame/wordgame.py
+++ b/wordgame/wordgame.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import secrets
 import string
@@ -95,11 +96,22 @@ class WordGame(commands.Cog):
         }
         self.config.register_guild(**default_guild)
 
+        # Per-thread locks prevent concurrent guesses from racing on claimed_positions
+        self._guess_locks: dict = {}
+
         self.bot.loop.create_task(self._register_persistent_views())
         self._close_games_loop.start()
 
     def cog_unload(self):
         self._close_games_loop.cancel()
+
+    def _get_thread_lock(self, thread_id: int):
+        """Return (creating if necessary) a per-thread asyncio.Lock."""
+        import asyncio
+
+        if thread_id not in self._guess_locks:
+            self._guess_locks[thread_id] = asyncio.Lock()
+        return self._guess_locks[thread_id]
 
     async def _register_persistent_views(self):
         """Re-register ScoreboardView for all active games after a restart."""
@@ -364,12 +376,20 @@ class WordGame(commands.Cog):
         except discord.HTTPException as e:
             log.error("Failed to update scoreboard: %s", e)
 
-    async def _process_guess(self, message: discord.Message, game: dict, guild):
+    async def _process_guess(self, message: discord.Message, guild):
         """Validate and score a guess, then update state and scoreboard."""
         guess = message.content.strip().lower()
-        word = game["word"]
-        user_id = str(message.author.id)
         thread = message.channel
+        user_id = str(message.author.id)
+
+        # Re-read fresh state here — the caller holds a per-thread lock so this
+        # read is guaranteed to reflect all previously committed guesses.
+        active_games = await self.config.guild(guild).active_games()
+        game = active_games.get(str(thread.id))
+        if not game or game.get("status") != "active":
+            return
+
+        word = game["word"]
 
         # Guard: player already done
         players = game.setdefault("players", {})
@@ -422,9 +442,12 @@ class WordGame(commands.Cog):
         game["claimed_positions"].extend(new_claims)
 
         guesses_used = len(player["guesses"])
-        if guesses_used >= player["max_guesses"] or guess == word:
+        word_found = guess == word
+        if word_found or guesses_used >= player["max_guesses"]:
             player["done"] = True
-            player["bonus_guess_at"] = time.time() + BONUS_GUESS_INTERVAL
+            # Only offer a bonus guess if the player ran out without finding the word
+            if not word_found:
+                player["bonus_guess_at"] = time.time() + BONUS_GUESS_INTERVAL
 
         # Reset the inactivity timer on every valid guess
         game["inactive_closes_at"] = time.time() + INACTIVITY_TIMEOUT
@@ -439,7 +462,7 @@ class WordGame(commands.Cog):
         reply = (
             f"{feedback_display}\n"
             f"**+{points} pts** | "
-            f"{'🎉 Correct!' if guess == word else f'{guesses_left} guess(es) left'}"
+            f"{'🎉 Correct!' if word_found else f'{guesses_left} guess(es) left'}"
         )
         try:
             await message.reply(reply)
@@ -478,4 +501,5 @@ class WordGame(commands.Cog):
         if not guess.isalpha() or len(guess) != game["length"]:
             return
 
-        await self._process_guess(message, game, message.guild)
+        async with self._get_thread_lock(int(thread_id)):
+            await self._process_guess(message, message.guild)


### PR DESCRIPTION
Fixes #188

## Summary

Three bugs in the wordgame cog:

1. **Game continued after correct guess** — a player who guessed the word correctly had `bonus_guess_at` set, so they received a bonus guess DM 5 minutes later and could keep guessing.
2. **Double position points** — concurrent guesses both read a stale snapshot of `claimed_positions`, so two players could each earn position bonus for the same `(letter, position)` pair.
3. **Letter dedup blocked position bonus** — the `seen_letters` `continue` also skipped the position-bonus check for repeated letters in the same guess (e.g. the second `p` in `poppy` would neither earn a letter bonus nor a position bonus, losing 1 pt).

## Changes

- `wordgame/game.py` — decouple letter bonus dedup from position bonus check; both are now evaluated independently per character
- `wordgame/wordgame.py` — add per-thread `asyncio.Lock`; `_process_guess` now acquires the lock and re-reads fresh Config state before scoring; skip `bonus_guess_at` when word is guessed correctly

## Testing

- Syntax validated: `python -m py_compile wordgame/game.py wordgame/wordgame.py`
- Scoring verified: 5-letter all-unique-correct = 12 pts (5 letter + 5 pos + 2 word), repeated-letter word like `poppy` = 10 pts max
