### PR TITLE
fix(video_dl): only suppress embed after confirmed video delivery

### DIFF
--- a/video_dl/video_dl.py
+++ b/video_dl/video_dl.py
@@ -45,6 +45,7 @@ class VideoDownloader(commands.Cog):
             r'(?:https?://)?(?:www\.)?instagram\.com/(?:reel|p)/[\w-]+/?'
         ),
     }
+
     def __init__(self, bot):
         self.bot = bot
         self.config = Config.get_conf(

--- a/video_dl/video_dl.py
+++ b/video_dl/video_dl.py
@@ -45,6 +45,7 @@ class VideoDownloader(commands.Cog):
             r'(?:https?://)?(?:www\.)?instagram\.com/(?:reel|p)/[\w-]+/?'
         ),
     }
+    
     def __init__(self, bot):
         self.bot = bot
         self.config = Config.get_conf(

--- a/video_dl/video_dl.py
+++ b/video_dl/video_dl.py
@@ -45,6 +45,9 @@ class VideoDownloader(commands.Cog):
             r'(?:https?://)?(?:www\.)?instagram\.com/(?:reel|p)/[\w-]+/?'
         ),
     }
+    VIDEO_EXTENSIONS = {
+        '.mp4', '.webm', '.mkv', '.mov', '.avi', '.flv', '.m4v', '.wmv',
+    }
 
     def __init__(self, bot):
         self.bot = bot
@@ -347,6 +350,7 @@ class VideoDownloader(commands.Cog):
             temp_dir = tempfile.mkdtemp(prefix='video_dl_')
 
             # Fetch cookies_file config for guild downloads
+            guild_config = {}
             cookies_file = ""
             if message.guild:
                 guild_config = await self.config.guild(message.guild).all()
@@ -362,35 +366,41 @@ class VideoDownloader(commands.Cog):
                     file_size = os.path.getsize(file_path)
                     file_size_limit = self._get_file_size_limit(message.guild)
 
+                    if Path(file_path).suffix.lower() not in self.VIDEO_EXTENSIONS:
+                        log.warning(f"Downloaded file does not appear to be a video: {file_path}")
                     # Try to send directly if within limit
-                    if file_size <= file_size_limit:
+                    elif file_size <= file_size_limit:
+                        delivered = False
                         try:
                             await message.reply(
                                 content=f"Downloaded from {platform.title()}:",
                                 file=discord.File(file_path)
                             )
-                            await self._remove_embed(message)
-                        except discord.HTTPException:
+                            delivered = True
+                        except Exception:
                             # Suppress errors for automatic downloads
                             pass
+
+                        if delivered:
+                            await self._remove_embed(message)
                     # Try catbox.moe if file is too large for Discord but within catbox limit
                     elif file_size <= self.CATBOX_SIZE_LIMIT:
-                        userhash = ""
-                        if message.guild:
-                            guild_config = await self.config.guild(message.guild).all()
-                            userhash = guild_config.get("catbox_userhash", "")
-
-                        success, catbox_url, error = await self._upload_to_catbox(file_path, userhash)
-                        if success and catbox_url:
+                        userhash = guild_config.get("catbox_userhash", "")
+                        upload_success, catbox_url, error = await self._upload_to_catbox(file_path, userhash)
+                        if upload_success and catbox_url:
+                            delivered = False
                             try:
                                 content_msg = (
                                     f"Downloaded from {platform.title()} "
                                     f"(too large for Discord, uploaded to catbox.moe):\n{catbox_url}"
                                 )
                                 await message.reply(content=content_msg)
-                                await self._remove_embed(message)
-                            except discord.HTTPException:
+                                delivered = True
+                            except Exception:
                                 pass
+
+                            if delivered:
+                                await self._remove_embed(message)
                         else:
                             # Catbox failed, react with emoji (guild only)
                             if message.guild:
@@ -403,7 +413,6 @@ class VideoDownloader(commands.Cog):
                         # File is too large even for catbox — react with emoji (guild only)
                         if message.guild:
                             try:
-                                guild_config = await self.config.guild(message.guild).all()
                                 emoji = guild_config.get("too_large_emoji", "💥")
                                 await message.add_reaction(emoji)
                             except discord.HTTPException:

--- a/video_dl/video_dl.py
+++ b/video_dl/video_dl.py
@@ -45,7 +45,6 @@ class VideoDownloader(commands.Cog):
             r'(?:https?://)?(?:www\.)?instagram\.com/(?:reel|p)/[\w-]+/?'
         ),
     }
-    
     def __init__(self, bot):
         self.bot = bot
         self.config = Config.get_conf(

--- a/video_dl/video_dl.py
+++ b/video_dl/video_dl.py
@@ -45,10 +45,6 @@ class VideoDownloader(commands.Cog):
             r'(?:https?://)?(?:www\.)?instagram\.com/(?:reel|p)/[\w-]+/?'
         ),
     }
-    VIDEO_EXTENSIONS = {
-        '.mp4', '.webm', '.mkv', '.mov', '.avi', '.flv', '.m4v', '.wmv',
-    }
-
     def __init__(self, bot):
         self.bot = bot
         self.config = Config.get_conf(
@@ -366,41 +362,34 @@ class VideoDownloader(commands.Cog):
                     file_size = os.path.getsize(file_path)
                     file_size_limit = self._get_file_size_limit(message.guild)
 
-                    if Path(file_path).suffix.lower() not in self.VIDEO_EXTENSIONS:
+                    video_extensions = {'.mp4', '.webm', '.mkv', '.mov', '.avi', '.flv', '.m4v', '.wmv'}
+                    if Path(file_path).suffix.lower() not in video_extensions:
                         log.warning(f"Downloaded file does not appear to be a video: {file_path}")
                     # Try to send directly if within limit
                     elif file_size <= file_size_limit:
-                        delivered = False
                         try:
                             await message.reply(
                                 content=f"Downloaded from {platform.title()}:",
                                 file=discord.File(file_path)
                             )
-                            delivered = True
+                            await self._remove_embed(message)
                         except Exception:
                             # Suppress errors for automatic downloads
                             pass
-
-                        if delivered:
-                            await self._remove_embed(message)
                     # Try catbox.moe if file is too large for Discord but within catbox limit
                     elif file_size <= self.CATBOX_SIZE_LIMIT:
                         userhash = guild_config.get("catbox_userhash", "")
                         upload_success, catbox_url, error = await self._upload_to_catbox(file_path, userhash)
                         if upload_success and catbox_url:
-                            delivered = False
                             try:
                                 content_msg = (
                                     f"Downloaded from {platform.title()} "
                                     f"(too large for Discord, uploaded to catbox.moe):\n{catbox_url}"
                                 )
                                 await message.reply(content=content_msg)
-                                delivered = True
+                                await self._remove_embed(message)
                             except Exception:
                                 pass
-
-                            if delivered:
-                                await self._remove_embed(message)
                         else:
                             # Catbox failed, react with emoji (guild only)
                             if message.guild:


### PR DESCRIPTION
Fixes #191

## Changes

- **Video extension validation**: Before attempting to send a downloaded file, validate it has a recognised video extension (`.mp4`, `.webm`, `.mkv`, etc.). If `yt-dlp` produces a non-video file (thumbnail, metadata, partial download), the embed is left intact instead of being suppressed.
- **Broader exception catch on delivery**: Changed `except discord.HTTPException` to `except Exception` on the `message.reply` call blocks. Any unexpected error during delivery (network timeout, API error, etc.) now preserves the original embed rather than potentially leaving the user with no video and no embed.

## Behaviour unchanged

- Embed is still suppressed immediately after a confirmed successful reply.
- Auth errors still get the ❌🍪 reaction.
- Files too large for Discord+catbox still get the configurable emoji reaction.