### PR TITLE
Add automatic Discord timestamps

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -240,6 +240,7 @@ async def mycommand(self, ctx):
 - **tgmc/**: API interface for TGMC game (requires: httpx, but not specified in info.json)
 - **user/**: Bot user management with nickname and avatar commands (no external deps)
 - **video_dl/**: Download videos from YouTube, TikTok, and Instagram via DM for bot owner only (requires: yt-dlp>=2023.1.1)
+- **when_cog/**: Detect common time expressions and reply with Discord timestamps (no external deps)
 
 ## Dependencies and Installation
 

--- a/tests/test_when_cog.py
+++ b/tests/test_when_cog.py
@@ -1,0 +1,37 @@
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from when_cog.parser import find_time
+
+
+@pytest.fixture
+def now():
+    return datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        ("See you in an hour.", datetime(2026, 7, 25, 13, 0, tzinfo=timezone.utc)),
+        ("Meet in 3 days.", datetime(2026, 7, 28, 12, 0, tzinfo=timezone.utc)),
+        ("Tomorrow at 7:30 pm", datetime(2026, 7, 26, 19, 30, tzinfo=timezone.utc)),
+        ("On Tuesday at 7", datetime(2026, 7, 28, 7, 0, tzinfo=timezone.utc)),
+    ],
+)
+def test_finds_supported_time_expressions(now, content, expected):
+    assert find_time(content, now) == expected
+
+
+def test_uses_configured_timezone_for_weekdays():
+    london = ZoneInfo("Europe/London")
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc).astimezone(london)
+
+    assert find_time("On Tuesday at 7", now) == datetime(
+        2026, 7, 28, 6, 0, tzinfo=timezone.utc
+    )
+
+
+def test_does_not_return_a_past_time_today(now):
+    assert find_time("today at 7am", now) is None

--- a/when_cog/__init__.py
+++ b/when_cog/__init__.py
@@ -1,0 +1,10 @@
+__red_end_user_data_statement__ = (
+    "This cog stores guild settings for enabled channels and timezones. "
+    "It does not persistently store personal user data."
+)
+
+
+async def setup(bot):
+    from .when_cog import WhenCog
+
+    await bot.add_cog(WhenCog(bot))

--- a/when_cog/info.json
+++ b/when_cog/info.json
@@ -1,0 +1,10 @@
+{
+    "author": ["psykzz"],
+    "name": "When",
+    "short": "Reply to time expressions with Discord timestamps",
+    "description": "Detects common relative and weekday time expressions in enabled channels and replies with a relative Discord timestamp.",
+    "permissions": ["Send Messages", "Read Message History"],
+    "requirements": [],
+    "tags": ["time", "timestamp", "utility"],
+    "end_user_data_statement": "This cog stores guild settings for enabled channels and timezones. It does not persistently store personal user data."
+}

--- a/when_cog/parser.py
+++ b/when_cog/parser.py
@@ -1,0 +1,111 @@
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+WEEKDAYS = {
+    "monday": 0,
+    "tuesday": 1,
+    "wednesday": 2,
+    "thursday": 3,
+    "friday": 4,
+    "saturday": 5,
+    "sunday": 6,
+}
+
+TIME_PATTERN = (
+    r"(?:[01]?\d|2[0-3])(?::[0-5]\d)?\s*(?:a\.?m\.?|p\.?m\.?)?"
+)
+RELATIVE_PATTERN = re.compile(
+    rf"\bin\s+(?P<amount>an?|one|\d+)\s+"
+    rf"(?P<unit>seconds?|minutes?|hours?|days?|weeks?)"
+    rf"(?:\s+at\s+(?P<time>{TIME_PATTERN}))?\b",
+    re.IGNORECASE,
+)
+DAY_PATTERN = re.compile(
+    rf"\b(?:on\s+)?(?:(?P<next>next)\s+)?"
+    rf"(?P<weekday>{'|'.join(WEEKDAYS)})\s+at\s+(?P<time>{TIME_PATTERN})\b",
+    re.IGNORECASE,
+)
+TODAY_TOMORROW_PATTERN = re.compile(
+    rf"\b(?P<day>today|tomorrow)(?:\s+at\s+(?P<time>{TIME_PATTERN}))?\b",
+    re.IGNORECASE,
+)
+CLOCK_PATTERN = re.compile(
+    r"^(?P<hour>\d{1,2})(?::(?P<minute>[0-5]\d))?\s*"
+    r"(?P<period>a\.?m\.?|p\.?m\.?)?$",
+    re.IGNORECASE,
+)
+
+
+def _parse_clock(value: str) -> Optional[tuple[int, int]]:
+    match = CLOCK_PATTERN.fullmatch(value.strip())
+    if not match:
+        return None
+
+    hour = int(match.group("hour"))
+    minute = int(match.group("minute") or 0)
+    period = (match.group("period") or "").lower().replace(".", "")
+    if period:
+        if not 1 <= hour <= 12:
+            return None
+        if period == "pm" and hour != 12:
+            hour += 12
+        elif period == "am" and hour == 12:
+            hour = 0
+    elif hour > 23:
+        return None
+    return hour, minute
+
+
+def _with_clock(value: datetime, clock: str) -> Optional[datetime]:
+    parsed_clock = _parse_clock(clock)
+    if parsed_clock is None:
+        return None
+    hour, minute = parsed_clock
+    return value.replace(hour=hour, minute=minute, second=0, microsecond=0)
+
+
+def find_time(content: str, now: datetime) -> Optional[datetime]:
+    """Return the first supported future time expression in UTC."""
+    if now.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+
+    relative_match = RELATIVE_PATTERN.search(content)
+    if relative_match:
+        amount_text = relative_match.group("amount").lower()
+        amount = 1 if amount_text in {"a", "an", "one"} else int(amount_text)
+        unit = relative_match.group("unit").lower().rstrip("s")
+        target = now + timedelta(**{unit + "s": amount})
+        clock = relative_match.group("time")
+        if clock:
+            target = _with_clock(target, clock)
+            if target is None:
+                return None
+        return target.astimezone(timezone.utc)
+
+    local_now = now
+    weekday_match = DAY_PATTERN.search(content)
+    if weekday_match:
+        weekday = WEEKDAYS[weekday_match.group("weekday").lower()]
+        days = (weekday - local_now.weekday()) % 7
+        if weekday_match.group("next"):
+            days += 7
+        target = _with_clock(local_now + timedelta(days=days), weekday_match.group("time"))
+        if target is None:
+            return None
+        if target <= local_now:
+            target += timedelta(days=7)
+        return target.astimezone(timezone.utc)
+
+    day_match = TODAY_TOMORROW_PATTERN.search(content)
+    if day_match:
+        days = 1 if day_match.group("day").lower() == "tomorrow" else 0
+        target = local_now + timedelta(days=days)
+        clock = day_match.group("time")
+        if clock:
+            target = _with_clock(target, clock)
+            if target is None or target <= local_now:
+                return None
+        return target.astimezone(timezone.utc)
+
+    return None

--- a/when_cog/when_cog.py
+++ b/when_cog/when_cog.py
@@ -1,0 +1,134 @@
+from datetime import timezone
+from typing import Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+import discord
+from redbot.core import Config, checks, commands
+
+from .parser import find_time
+
+IDENTIFIER = 724689030408665012
+
+
+class WhenCog(commands.Cog):
+    """Reply to common time expressions with relative Discord timestamps."""
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.config = Config.get_conf(
+            self, identifier=IDENTIFIER, force_registration=True
+        )
+        self.config.register_guild(
+            enabled=False,
+            enabled_channels=[],
+            timezone="UTC",
+        )
+
+    async def red_delete_data_for_user(self, *, requester: str, user_id: int):
+        """This cog does not store user data."""
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        """Reply when an enabled channel contains a supported time expression."""
+        if message.guild is None or message.author.bot or not message.content:
+            return
+
+        guild_config = self.config.guild(message.guild)
+        enabled = await guild_config.enabled()
+        enabled_channels = await guild_config.enabled_channels()
+        if not enabled and message.channel.id not in enabled_channels:
+            return
+
+        timezone_name = await guild_config.timezone()
+        try:
+            guild_timezone = ZoneInfo(timezone_name)
+        except ZoneInfoNotFoundError:
+            guild_timezone = timezone.utc
+
+        timestamp = find_time(
+            message.content,
+            message.created_at.astimezone(guild_timezone),
+        )
+        if timestamp is not None:
+            await message.reply(
+                f"<t:{int(timestamp.timestamp())}:R>",
+                allowed_mentions=discord.AllowedMentions.none(),
+            )
+
+    @commands.hybrid_group(name="when")
+    @commands.guild_only()
+    @checks.admin_or_permissions(manage_guild=True)
+    async def when(self, ctx):
+        """Configure automatic Discord timestamp replies."""
+
+    @when.command(name="status")
+    async def status(self, ctx):
+        """Show the current When configuration."""
+        config = await self.config.guild(ctx.guild).all()
+        channels = [
+            channel.mention
+            for channel_id in config["enabled_channels"]
+            if (channel := ctx.guild.get_channel(channel_id)) is not None
+        ]
+        scope = "all channels" if config["enabled"] else ", ".join(channels) or "none"
+        await ctx.send(
+            f"When is enabled in: {scope}. Timezone: `{config['timezone']}`."
+        )
+
+    @when.command(name="on")
+    async def enable_guild(self, ctx):
+        """Enable When in every channel in this server."""
+        await self.config.guild(ctx.guild).enabled.set(True)
+        await ctx.send("When is now enabled in every channel.")
+
+    @when.command(name="off")
+    async def disable_guild(self, ctx):
+        """Disable server-wide When replies; enabled channels stay enabled."""
+        await self.config.guild(ctx.guild).enabled.set(False)
+        await ctx.send("When is now disabled server-wide.")
+
+    @when.group(name="channel")
+    async def channel(self, ctx):
+        """Configure individual channels."""
+
+    @channel.command(name="on")
+    async def enable_channel(
+        self, ctx, channel: Optional[discord.TextChannel] = None
+    ):
+        """Enable When in one channel."""
+        channel = channel or ctx.channel
+        enabled_channels = await self.config.guild(ctx.guild).enabled_channels()
+        if channel.id in enabled_channels:
+            await ctx.send(f"When is already enabled in {channel.mention}.")
+            return
+        enabled_channels.append(channel.id)
+        await self.config.guild(ctx.guild).enabled_channels.set(enabled_channels)
+        await ctx.send(f"When is now enabled in {channel.mention}.")
+
+    @channel.command(name="off")
+    async def disable_channel(
+        self, ctx, channel: Optional[discord.TextChannel] = None
+    ):
+        """Disable one channel-specific When setting."""
+        channel = channel or ctx.channel
+        enabled_channels = await self.config.guild(ctx.guild).enabled_channels()
+        if channel.id not in enabled_channels:
+            await ctx.send(f"When is already disabled in {channel.mention}.")
+            return
+        enabled_channels.remove(channel.id)
+        await self.config.guild(ctx.guild).enabled_channels.set(enabled_channels)
+        await ctx.send(f"When is now disabled in {channel.mention}.")
+
+    @when.command(name="timezone")
+    async def set_timezone(self, ctx, *, timezone_name: str):
+        """Set the IANA timezone used for weekday and clock expressions."""
+        try:
+            ZoneInfo(timezone_name)
+        except ZoneInfoNotFoundError:
+            await ctx.send(
+                "That is not a valid IANA timezone, for example `Europe/London`."
+            )
+            return
+
+        await self.config.guild(ctx.guild).timezone.set(timezone_name)
+        await ctx.send(f"When timezone set to `{timezone_name}`.")


### PR DESCRIPTION
## Summary

Adds the disabled-by-default When cog, which detects common time expressions and
replies with Discord relative timestamps.

## Changes

- Support server-wide and per-channel enablement.
- Add configurable IANA timezones for weekday and clock expressions.
- Cover supported expressions with focused parser tests.

## Testing

- `pytest tests\test_when_cog.py -q`
- `python -m py_compile when_cog\__init__.py when_cog\parser.py when_cog\when_cog.py tests\test_when_cog.py`
- `flake8 when_cog tests\test_when_cog.py --count --statistics`

## Risk

The cog is disabled by default. Its behavior is limited to configured guilds and
channels.
