### PR TITLE
Fix automatic timestamp expressions

### DIFF
--- a/tests/test_when_cog.py
+++ b/tests/test_when_cog.py
@@ -37,3 +37,8 @@ def test_uses_configured_timezone_for_weekdays():
 
 def test_does_not_return_a_past_time_today(now):
     assert find_time("today at 7am", now) is None
+
+
+@pytest.mark.parametrize("content", ["today", "tomorrow"])
+def test_does_not_return_a_timestamp_for_a_bare_day(content, now):
+    assert find_time(content, now) is None

--- a/tests/test_when_cog.py
+++ b/tests/test_when_cog.py
@@ -16,6 +16,8 @@ def now():
     [
         ("See you in an hour.", datetime(2026, 7, 25, 13, 0, tzinfo=timezone.utc)),
         ("Meet in 3 days.", datetime(2026, 7, 28, 12, 0, tzinfo=timezone.utc)),
+        ("It was 5 minutes ago.", datetime(2026, 7, 25, 11, 55, tzinfo=timezone.utc)),
+        ("An hour ago", datetime(2026, 7, 25, 11, 0, tzinfo=timezone.utc)),
         ("Tomorrow at 7:30 pm", datetime(2026, 7, 26, 19, 30, tzinfo=timezone.utc)),
         ("On Tuesday at 7", datetime(2026, 7, 28, 7, 0, tzinfo=timezone.utc)),
     ],

--- a/when_cog/parser.py
+++ b/when_cog/parser.py
@@ -21,6 +21,11 @@ RELATIVE_PATTERN = re.compile(
     rf"(?:\s+at\s+(?P<time>{TIME_PATTERN}))?\b",
     re.IGNORECASE,
 )
+PAST_PATTERN = re.compile(
+    r"\b(?P<amount>an?|one|\d+)\s+"
+    r"(?P<unit>seconds?|minutes?|hours?|days?|weeks?)\s+ago\b",
+    re.IGNORECASE,
+)
 DAY_PATTERN = re.compile(
     rf"\b(?:on\s+)?(?:(?P<next>next)\s+)?"
     rf"(?P<weekday>{'|'.join(WEEKDAYS)})\s+at\s+(?P<time>{TIME_PATTERN})\b",
@@ -66,7 +71,7 @@ def _with_clock(value: datetime, clock: str) -> Optional[datetime]:
 
 
 def find_time(content: str, now: datetime) -> Optional[datetime]:
-    """Return the first supported future time expression in UTC."""
+    """Return the first supported time expression in UTC."""
     if now.tzinfo is None:
         raise ValueError("now must be timezone-aware")
 
@@ -81,6 +86,14 @@ def find_time(content: str, now: datetime) -> Optional[datetime]:
             target = _with_clock(target, clock)
             if target is None:
                 return None
+        return target.astimezone(timezone.utc)
+
+    past_match = PAST_PATTERN.search(content)
+    if past_match:
+        amount_text = past_match.group("amount").lower()
+        amount = 1 if amount_text in {"a", "an", "one"} else int(amount_text)
+        unit = past_match.group("unit").lower().rstrip("s")
+        target = now - timedelta(**{unit + "s": amount})
         return target.astimezone(timezone.utc)
 
     local_now = now

--- a/when_cog/parser.py
+++ b/when_cog/parser.py
@@ -32,7 +32,7 @@ DAY_PATTERN = re.compile(
     re.IGNORECASE,
 )
 TODAY_TOMORROW_PATTERN = re.compile(
-    rf"\b(?P<day>today|tomorrow)(?:\s+at\s+(?P<time>{TIME_PATTERN}))?\b",
+    rf"\b(?P<day>today|tomorrow)\s+at\s+(?P<time>{TIME_PATTERN})\b",
     re.IGNORECASE,
 )
 CLOCK_PATTERN = re.compile(
@@ -113,12 +113,9 @@ def find_time(content: str, now: datetime) -> Optional[datetime]:
     day_match = TODAY_TOMORROW_PATTERN.search(content)
     if day_match:
         days = 1 if day_match.group("day").lower() == "tomorrow" else 0
-        target = local_now + timedelta(days=days)
-        clock = day_match.group("time")
-        if clock:
-            target = _with_clock(target, clock)
-            if target is None or target <= local_now:
-                return None
+        target = _with_clock(local_now + timedelta(days=days), day_match.group("time"))
+        if target is None or target <= local_now:
+            return None
         return target.astimezone(timezone.utc)
 
     return None


### PR DESCRIPTION
## Summary

Fixes two time-expression gaps identified after the initial When cog merge.

## Changes

- Parse elapsed expressions such as `5 minutes ago`.
- Require `at <time>` for `today` and `tomorrow` expressions.

## Testing

- `pytest tests\test_when_cog.py -q`
- `python -m py_compile when_cog\parser.py tests\test_when_cog.py`
- `flake8 when_cog\parser.py tests\test_when_cog.py --count --statistics`

## Risk

The change narrows automatic replies for bare day names while adding expected
elapsed timestamps.
